### PR TITLE
Exported as module and npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+bower_components
+test
+tests
+spec

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "websql-promise",
+  "version": "1.0.2",
+  "description": "Light promise wrapper over WebSQL, and ES6 iterator",
+  "main": "websql-promise.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MetaMemoryT/websql-promise.git"
+  },
+  "author": "Sean Usick <sean258@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/MetaMemoryT/websql-promise/issues"
+  },
+  "homepage": "https://github.com/MetaMemoryT/websql-promise#readme"
+}

--- a/websql-promise.js
+++ b/websql-promise.js
@@ -32,3 +32,5 @@ SQLIterator.prototype[Symbol.iterator] = function*() {
     yield this.rows.item(i);
   }
 };
+
+module.exports = DB;


### PR DESCRIPTION
Exported as a module, can then be used as
`import DB from 'websql-promise` in ES6 or
`var DB = require('websql-promise')` in ES5.
